### PR TITLE
Escape curly braces in markdown

### DIFF
--- a/cli/src/prebuild.ts
+++ b/cli/src/prebuild.ts
@@ -119,6 +119,7 @@ const populateTemplate = (contents: string, title: string, templateContents: str
             'MARKDOWN_PLACEHOLDER',
             contents
             .replace(/`/gu, '\\`')
+            .replace(/(\{|\})/gu, "{'$1'}")
         )
         .replace('TITLE_PLACEHOLDER', kabobToSentenceCase(title))
 }


### PR DESCRIPTION
Escapes all curly braces in markdown before it is inserted into the template.

This should resolve the problems encountered in https://github.com/finale-lua/lua-scripts/pull/405